### PR TITLE
Set GPU device index in whisper model

### DIFF
--- a/Scripts/transcribe.py
+++ b/Scripts/transcribe.py
@@ -755,6 +755,7 @@ def transcribeLoop(mic: str,
         model = model_root
     model = WhisperModel(model,
             device = model_device,
+            device_index = gpu_idx,
             compute_type = "int8",
             download_root = model_root,
             local_files_only = download_it)


### PR DESCRIPTION
`gpu_idx` passed in argument are not used in transcribing function, this pull request fixes that issue.